### PR TITLE
Updated to use regular expression to parse storyId

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -76,10 +76,12 @@ function validateStoryUrl($url) {
 
 function getFFNetStoryID($url)
 {
-    $out = $url;
-    $startsAt = strpos($out, "/s/") + strlen("/s/");
-    $endsAt = strpos($out, "/", $startsAt);
-    $result = substr($out, $startsAt, $endsAt - $startsAt);
-    return $result;
+	$success = preg_match("/https:\/\/www\.[a-z\.]+\/s\/([0-9]+)/", $url, $match);
+	if($success) {
+		return $match[1];
+	} else {
+		return "";
+	}
+	
 }
 ?>


### PR DESCRIPTION
I was trying to figure out why I got an error whenever I put in the following url:

https://www.fanfiction.net/s/11293050

turns out i needed a trailing slash on the URL and everything worked.

went through and found that if you use a regex when parsing the storyId you can optionally have that trailing slash.. 