### PR TITLE
fixed fatal_error due to custom include donations.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "querypath/QueryPath": "^3.0",
         "masterminds/html5": "^2.1",
         "slim/logger": "^0.1.0",
-        "grandt/phpepub": "^4.0"
+        "grandt/phpepub": "<=4.0.5"
     },
     "authors": [
         {

--- a/pages/index.php
+++ b/pages/index.php
@@ -83,7 +83,7 @@
                 </div>
                 <?php
                 try {
-                    require dirname(dirname(__FILE__)) . '/include/custom/donations.php';
+                    include dirname(dirname(__FILE__)) . '/include/custom/donations.php';
                 ?>
                 <div class="row">
                     <div class="col s12 center-align" style="margin: 20px auto 5px auto;">


### PR DESCRIPTION
Hi @waylaidwanderer 

I'm getting the following error when running the local copy-

```html
<b>Warning</b>:  Uncaught exception 'ErrorException' with message 'require(/var/www/FicSave/include/custom/donations.php): failed to open stream: No such file or directory' in /var/www/FicSave/pages/index.php:86
Stack trace:
#0 /var/www/FicSave/pages/index.php(86): Slim\Slim::handleErrors(2, 'require(/var/ww...', '/var/www/FicSav...', 86, Array)
#1 /var/www/FicSave/pages/index.php(86): require()
#2 /var/www/FicSave/index.php(24): require('/var/www/FicSav...')
#3 [internal function]: {closure}()
#4 /var/www/FicSave/vendor/slim/slim/Slim/Route.php(468): call_user_func_array(Object(Closure), Array)
#5 /var/www/FicSave/vendor/slim/slim/Slim/Slim.php(1356): Slim\Route->dispatch()
#6 /var/www/FicSave/vendor/slim/slim/Slim/Middleware/Flash.php(85): Slim\Slim->call()
#7 /var/www/FicSave/vendor/slim/slim/Slim/Middleware/MethodOverride.php(92): Slim\Middleware\Flash->call()
#8 /var/www/FicSave/vendor/slim/slim/Slim/Slim.php(1302): Slim\Middleware\MethodOverride->call()
#9 /var/www/FicSave/index.php(293): Slim\Slim->run()
#10 {main}
  t in <b>/var/www/FicSave/pages/index.php</b> on line <b>86</b><br />
<br />
<b>Fatal error</b>:  main(): Failed opening required '/var/www/FicSave/include/custom/donations.php' (include_path='.:/usr/share/php:/usr/share/pear') in <b>/var/www/FicSave/pages/index.php</b> on line <b>86</b><br />
```


It is being caused by 
```php
 require dirname(dirname(__FILE__)) . '/include/custom/donations.php';
```
in the file `pages/index.php`

As there is no `/include/custom` folder currently, it throws a fatal error due to `require`

I'm replacing the require there with include to fix it.