### PR TITLE
Master

### DIFF
--- a/app/Ficsave/Ficsave.php
+++ b/app/Ficsave/Ficsave.php
@@ -13,6 +13,7 @@ use App\Ficsave\Sites\AdultFanfiction;
 use App\Ficsave\Sites\AsianFanfics;
 use App\Ficsave\Sites\FanfictionNet;
 use App\Ficsave\Sites\HpFanficArchive;
+use App\Ficsave\Sites\RoyalRoad;
 
 class Ficsave
 {
@@ -29,6 +30,8 @@ class Ficsave
                 return HpFanficArchive::getChapter($url, $chapterNumber, $metadata);
             } else if ($host == 'www.asianfanfics.com') {
                 return AsianFanfics::getChapter($url, $chapterNumber);
+            } else if ($host == 'www.royalroad.com') {
+                return RoyalRoad::getChapter($url, $chapterNumber, $metadata);
             } else {
                 throw new FicSaveException("This should never happen.");
             }
@@ -36,7 +39,7 @@ class Ficsave
         } catch (\Exception $ex) {
             \Log::debug($ex);
             if ($retries === 3) {
-                throw new FicSaveException("Failed to download chapter {$chapterNumber} of {$url} (1).");
+                throw new FicSaveException("Failed to download chapter {$chapterNumber} of {$url} ({$retries}) (1).");
             }
             return self::getChapter($url, $chapterNumber, $metadata, $retries + 1);
         }
@@ -59,6 +62,8 @@ class Ficsave
                 return HpFanficArchive::getInfo($url);
             } else if ($host == 'www.asianfanfics.com') {
                 return AsianFanfics::getInfo($url);
+            } else if ($host == 'www.royalroad.com') {
+                return RoyalRoad::getInfo($url);
             }
             throw new FicSaveException("That website is not supported by FicSave :(");
         } else {

--- a/app/Ficsave/Ficsave.php
+++ b/app/Ficsave/Ficsave.php
@@ -14,6 +14,7 @@ use App\Ficsave\Sites\AsianFanfics;
 use App\Ficsave\Sites\FanfictionNet;
 use App\Ficsave\Sites\HpFanficArchive;
 use App\Ficsave\Sites\RoyalRoad;
+use App\Ficsave\Sites\MoodyLit;
 
 class Ficsave
 {
@@ -32,6 +33,8 @@ class Ficsave
                 return AsianFanfics::getChapter($url, $chapterNumber);
             } else if ($host == 'www.royalroad.com') {
                 return RoyalRoad::getChapter($url, $chapterNumber, $metadata);
+            } else if ($host == 'moodylit.com') {
+                return MoodyLit::getChapter($url, $chapterNumber, $metadata);
             } else {
                 throw new FicSaveException("This should never happen.");
             }
@@ -64,6 +67,8 @@ class Ficsave
                 return AsianFanfics::getInfo($url);
             } else if ($host == 'www.royalroad.com') {
                 return RoyalRoad::getInfo($url);
+            } else if ($host == 'moodylit.com') {
+                return MoodyLit::getInfo($url);
             }
             throw new FicSaveException("That website is not supported by FicSave :(");
         } else {

--- a/app/Ficsave/Sites/FanfictionNet.php
+++ b/app/Ficsave/Sites/FanfictionNet.php
@@ -102,7 +102,8 @@ class FanfictionNet
                 $numChapters = qp($html, '#chap_select')->find('option')->count() / 2; // value is always doubled for some reason
                 $story->chapters = $numChapters == 0 ? 1 : $numChapters;
 
-                $coverImageUrl = qp($html, '#profile_top')->find('img')->first()->attr('src');
+                $coverImageUrl = qp($html, 'img.cimage:not(.lazy)')->attr('src');
+
                 if ($coverImageUrl != null) {
                     $coverImageUrlParts = parse_url($coverImageUrl);
                     if (!isset($coverImageUrlParts['scheme']) && substr($coverImageUrl, 0, 2) == '//') {

--- a/app/Ficsave/Sites/MoodyLit.php
+++ b/app/Ficsave/Sites/MoodyLit.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Joel
+ * Date: 2016-06-15
+ * Time: 7:36 PM
+ */
+
+namespace App\Ficsave\Sites;
+
+
+use App\Ficsave\Chapter;
+use App\Ficsave\FicSaveException;
+use App\Ficsave\Story;
+use App\Helper;
+use Masterminds\HTML5;
+
+class MoodyLit
+{
+    public static function getChapter($url, $chapterNumber, $metadata) {
+        $chapter = new Chapter;
+        $chapter->number = $chapterNumber;
+        $chapter->title = $metadata[$chapterNumber - 1 ][1];
+
+        $response = "";
+        for ($j = 0; $j < 10; $j++) {
+            $response = Helper::cURL($metadata[$chapterNumber - 1][0]);
+            if (!empty($response)) break;
+            sleep(1);
+        }
+
+        $html = new HTML5;
+        $html = $html->loadHTML($response);
+
+        $paragraphs = qp($html, 'p');
+        foreach ($paragraphs as $p){
+            $chapter->content .= $p->html();
+        }
+
+        #$chapter->content = Helper::stripAttributes(qp($html, '#chapter-content')->innerHTML());
+        #$chapter->content = qp($html, '.chapter-content')->innerHTML();
+
+        return $chapter;
+    }
+
+    public static function getInfo($url) {
+
+        $response = "";
+        for ($i = 0; $i < 10; $i++) {
+            $response = Helper::cURL($url);
+            if (!empty($response)) break;
+            sleep(1);
+        }
+        $html = new HTML5;
+        $html = $html->loadHTML($response);
+
+        $story = new Story;
+
+        # CYA: I don't know if id must be numeric or not, so force it to a unique number based on url.
+        $storyId = base_convert(hash("md5",$url),16,10);
+        $story->id = $storyId;
+        $story->url = $url;
+
+        $title = trim(qp($html, 'h1.leader')->text());
+        if (empty($title)) {
+            throw new FicSaveException("Could not retrieve title for story at $url.");
+        } else {
+            $story->title = $title;
+        }
+
+        $author = "V. Moody";
+        if (empty($author)) {
+            throw new FicSaveException("Could not retrieve author for story at $url.");
+        } else {
+            $story->author = $author;
+        }
+
+        $a = qp($html,'div.align-justify');
+        $description = $a->innerHTML();
+        if ($description == null) {
+            throw new FicSaveException("Could not retrieve description for story at $url.");
+        } else {
+            $story->description = $description;
+        }
+
+        # Chapters are listed in a table. Count the rows and store the URLs.
+
+        $tableRows = qp($html, 'table#category-book-toc')->find('tbody')->find('tr');
+        $story->metadata = array();
+
+        foreach ($tableRows as $row) {
+            $a = $row->find('a');
+
+            $url = "http://moodylit.com" . ($a->attr('href'));
+            $t = trim($a->text());
+
+            # Push array of URL & title onto metadata array
+            $story->metadata[] = array($url,$t);
+        }
+
+        $numChapters = sizeof($story->metadata);
+        $story->chapters = $numChapters == 0 ? 1 : $numChapters;
+
+        $coverImageUrl = qp($html, 'img.book-cover')->attr("src");
+        if ($coverImageUrl != null) {
+            $story->coverImageUrl = "http://moodylit.com" . $coverImageUrl;
+        }
+
+        return $story;
+    }
+}

--- a/app/Ficsave/Sites/RoyalRoad.php
+++ b/app/Ficsave/Sites/RoyalRoad.php
@@ -100,6 +100,15 @@ class RoyalRoad
                 $story->chapters = $numChapters == 0 ? 1 : $numChapters;
 
                 $coverImageUrl = qp($html, 'meta[name="og:image"]')->attr("content");
+                if ($coverImageUrl == null || $coverImageUrl === "") {
+                    $coverImageUrl = qp($html, 'meta[name="twitter:image"]')->attr("content");
+                }
+                if ($coverImageUrl == null || $coverImageUrl === "") {
+                    $coverImageUrl = qp($html, 'img.thumbnail')->attr("src");
+                }
+                if ($coverImageUrl == null || $coverImageUrl === "") {
+                    $coverImageUrl = qp($html, 'img.thumbnail')->attr("src");
+                }
                 if ($coverImageUrl != null) {
                     if( strpos($coverImageUrl, "http") === 0 ){
                         $story->coverImageUrl = $coverImageUrl;

--- a/app/Ficsave/Sites/RoyalRoad.php
+++ b/app/Ficsave/Sites/RoyalRoad.php
@@ -15,15 +15,12 @@ use App\Ficsave\Story;
 use App\Helper;
 use Masterminds\HTML5;
 
-ini_set('display_errors', 'On');
-error_reporting(E_ALL | E_STRICT);
-
 class RoyalRoad
 {
     public static function getChapter($url, $chapterNumber, $metadata) {
         $chapter = new Chapter;
         $chapter->number = $chapterNumber;
-        $chapter->title = $metadata[$chapterNumber][1];
+        $chapter->title = $metadata[$chapterNumber - 1 ][1];
 
         $response = "";
         for ($j = 0; $j < 10; $j++) {
@@ -104,12 +101,12 @@ class RoyalRoad
 
                 $coverImageUrl = qp($html, 'meta[name="og:image"]')->attr("content");
                 if ($coverImageUrl != null) {
-                    $coverImageUrlParts = parse_url($coverImageUrl);
-                    if (!isset($coverImageUrlParts['scheme']) && substr($coverImageUrl, 0, 2) == '//') {
-                        $coverImageUrl = $urlParts['scheme'] . ":" . $coverImageUrl;
+                    if( strpos($coverImageUrl, "http") === 0 ){
+                        $story->coverImageUrl = $coverImageUrl;
                     }
-                    $coverImageUrl = str_replace('/75/', '/180/', $coverImageUrl);
-                    $story->coverImageUrl = $coverImageUrl;
+                    else{
+                        $story->coverImageUrl = "http://www.royalroad.com" . $coverImageUrl;
+                    }
                 }
 
                 return $story;

--- a/app/Ficsave/Sites/RoyalRoad.php
+++ b/app/Ficsave/Sites/RoyalRoad.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Joel
+ * Date: 2016-06-15
+ * Time: 7:36 PM
+ */
+
+namespace App\Ficsave\Sites;
+
+
+use App\Ficsave\Chapter;
+use App\Ficsave\FicSaveException;
+use App\Ficsave\Story;
+use App\Helper;
+use Masterminds\HTML5;
+
+ini_set('display_errors', 'On');
+error_reporting(E_ALL | E_STRICT);
+
+class RoyalRoad
+{
+    public static function getChapter($url, $chapterNumber, $metadata) {
+        $chapter = new Chapter;
+        $chapter->number = $chapterNumber;
+        $chapter->title = $metadata[$chapterNumber][1];
+
+        $response = "";
+        for ($j = 0; $j < 10; $j++) {
+            $response = Helper::cURL($metadata[$chapterNumber - 1][0]);
+            if (!empty($response)) break;
+            sleep(1);
+        }
+
+        $html = new HTML5;
+        $html = $html->loadHTML($response);
+
+        #$chapter->content = Helper::stripAttributes(qp($html, '#chapter-content')->innerHTML());
+        $chapter->content = qp($html, '.chapter-content')->innerHTML();
+
+        return $chapter;
+    }
+
+    public static function getInfo($url) {
+        $urlParts = parse_url($url);
+        $pathParts = explode('/', $urlParts['path']);
+        if (isset($pathParts[3])) {
+            $storyId = $pathParts[2];
+            if (is_numeric($storyId)) {
+                $response = "";
+                for ($i = 0; $i < 10; $i++) {
+                    $response = Helper::cURL($url);
+                    if (!empty($response)) break;
+                    sleep(1);
+                }
+                $html = new HTML5;
+                $html = $html->loadHTML($response);
+
+                $story = new Story;
+                $story->id = $storyId;
+                $urlParts = parse_url($url);
+                $story->url = "{$urlParts['scheme']}://{$urlParts['host']}/fiction/{$storyId}/{$pathParts[3]}";
+
+                $title = qp($html, 'meta[name="twitter:title"]')->attr("content");
+                if (empty($title)) {
+                    throw new FicSaveException("Could not retrieve title for story at $url.");
+                } else {
+                    $story->title = $title;
+                }
+
+                $author = qp($html, 'meta[name="twitter:creator"]')->attr("content");
+                if (empty($author)) {
+                    throw new FicSaveException("Could not retrieve author for story at $url.");
+                } else {
+                    $story->author = $author;
+                }
+
+                $description = qp($html, 'div.description')->text();
+                if ($description == null) {
+                    throw new FicSaveException("Could not retrieve description for story at $url.");
+                } else {
+                    $story->description = $description;
+                        #Helper::stripAttributes(preg_replace('/<a(.*?)>(.*?)<\/a>/', '\2', trim(qp($description)->html() . qp($description)->next()->html())));
+                }
+
+                # Chapters are listed in a table. Count the rows and store the URLs.
+
+                $tableRows = qp($html, 'table#chapters')->find('tbody')->find('tr');
+                #$story->chaptersList = array();
+                $story->metadata = array();
+
+                foreach ($tableRows as $row) {
+                    $a = $row->find('td')->first()->find('a');
+
+                    $url = "http://www.royalroad.com" . ($a->attr('href'));
+                    $t = trim($a->text());
+
+                    # Push array of URL & title onto metadata array
+                    $story->metadata[] = array($url,$t);
+                }
+
+                $numChapters = sizeof($story->metadata);
+                $story->chapters = $numChapters == 0 ? 1 : $numChapters;
+
+                $coverImageUrl = qp($html, 'meta[name="og:image"]')->attr("content");
+                if ($coverImageUrl != null) {
+                    $coverImageUrlParts = parse_url($coverImageUrl);
+                    if (!isset($coverImageUrlParts['scheme']) && substr($coverImageUrl, 0, 2) == '//') {
+                        $coverImageUrl = $urlParts['scheme'] . ":" . $coverImageUrl;
+                    }
+                    $coverImageUrl = str_replace('/75/', '/180/', $coverImageUrl);
+                    $story->coverImageUrl = $coverImageUrl;
+                }
+
+                return $story;
+            } else {
+                throw new FicSaveException("URL has an invalid story ID: $storyId.");
+            }
+        } else {
+            throw new FicSaveException("URL is missing story ID.");
+        }
+    }
+}

--- a/app/Helper.php
+++ b/app/Helper.php
@@ -47,7 +47,10 @@ class Helper
             'verify' => false,
             'headers' => [
                 'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:64.0) Gecko/20100101 Firefox/64.0',
+                'Accept' => "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
                 'Accept-Encoding' => 'gzip',
+                # 'Accept-Language' => "en-US,en;q=0.5",
+                # 'Host' => "www.hpfanficarchive.com", ("Host" is automatically added by guzzle middleware)
             ],
             'timeout' => 10,
         ];
@@ -63,6 +66,10 @@ class Helper
             $opts['proxy'] = 'http://' . $proxy;
         }
         $client = new \GuzzleHttp\Client($opts);
+
+        # A blank "referer" is "bad behavior" TODO: Just don't set it then!
+        if($referrer === '')
+            $referrer = "http://www.google.com";
         $response = $client->get($url, [
             'headers' => [
                 'Referer' => $referrer,

--- a/app/Jobs/StoryDownload.php
+++ b/app/Jobs/StoryDownload.php
@@ -106,6 +106,10 @@ class StoryDownload extends Job implements ShouldQueue
             $book->setAuthor($story->author, $story->author);
             $book->setIdentifier($download->getId(), EPub::IDENTIFIER_UUID);
             $book->setSourceURL($story->url);
+            if (!empty($story->coverImageUrl)){
+                #TODO: This operation is expensive (http fetch) retry if fails, etc.
+                $book->setCoverImage("Cover.jpg", Helper::cURL($story->coverImageUrl));
+            }
             if (!empty($story->description)) {
                 $book->setDescription($story->description);
             }


### PR DESCRIPTION
OK, Hopefully this pull request is a bit cleaner.

Also, with the fix of missing headers in requests to "hpfanfiction.com" I think I'm done for now.

Cover image downloading (and including in the epub) works for fanfiction.com and royalroad. hpfanfiction doesn't have them, and I didn't test the other two.

It would be nice to reduce the fields of the "$story" struct that are passed via the heartbeat to the client, that would allow us to download covers at initial start instead of when done, which seems like it'd be more appropriate.

Eventually, some sort of generic "I don't know that site, but point me at the TOC page and I'll try" option would be nice. So would a more plugin like method of adding sites. I've had to roll my own download and compile into and ebook stuff too often, so hopefully this will help others avoid that.
